### PR TITLE
Implemented catalog search with active filters

### DIFF
--- a/src/features/Stocks/Catalogs/Strains/StrainCatalogContainer.test.tsx
+++ b/src/features/Stocks/Catalogs/Strains/StrainCatalogContainer.test.tsx
@@ -21,9 +21,13 @@ import {
   mockBacterialStrains,
   availableStrains,
 } from "./mockData"
+import userEvent from "@testing-library/user-event"
 
-jest.mock("react-virtualized-auto-sizer", () => ({ children }: any) =>
-  children({ height: 535, width: 600 }),
+jest.mock(
+  "react-virtualized-auto-sizer",
+  () =>
+    ({ children }: any) =>
+      children({ height: 535, width: 600 }),
 )
 
 jest.mock("react-router-dom", () => {
@@ -244,6 +248,41 @@ describe("Stocks/Strains/StrainCatalogContainer", () => {
           filter: "name=~GWDI",
         },
       })
+    })
+  })
+
+  describe("strains dropdown and chips", () => {
+    const listStrainMocks = [
+      {
+        request: {
+          query: StrainListDocument,
+          variables: {
+            cursor: 0,
+            filter: "",
+            limit: 10,
+          },
+        },
+        result: {
+          data: {
+            listStrains: lastFiveStrainCatalogItems,
+          },
+        },
+      },
+    ]
+
+    it("should have appbar-dropdown", () => {
+      render(<MockComponent mocks={listStrainMocks} filter="all" />)
+      expect(screen.getByRole("appbar-dropdown")).toBeInTheDocument()
+    })
+
+    it("should have 1 chip for filter=regular", () => {
+      render(<MockComponent mocks={listStrainMocks} filter="regular" />)
+      expect(screen.getAllByRole("chip")).toHaveLength(1)
+    })
+
+    it("should have 2 chips for filter=available", () => {
+      render(<MockComponent mocks={listStrainMocks} filter="available" />)
+      expect(screen.getAllByRole("chip")).toHaveLength(2)
     })
   })
 })

--- a/src/features/Stocks/Catalogs/Strains/StrainCatalogContainer.tsx
+++ b/src/features/Stocks/Catalogs/Strains/StrainCatalogContainer.tsx
@@ -161,16 +161,33 @@ const StrainCatalogContainer = ({ filter }: Props) => {
     const updateData = async () => {
       switch (filter) {
         case "regular":
+          dispatch({
+            type: CatalogActionType.SET_ACTIVE_FILTERS,
+            payload: ["Regular"]
+          })
+          break
         case "gwdi":
+          dispatch({
+            type: CatalogActionType.SET_ACTIVE_FILTERS,
+            payload: ["GWDI"],
+          })
           dispatchStrainList(dispatch, filter)
           break
         case "bacterial":
+          dispatch({
+            type: CatalogActionType.SET_ACTIVE_FILTERS,
+            payload: ["Bacterial"],
+          })
           dispatch({
             type: CatalogActionType.SET_QUERY,
             payload: ListBacterialStrainsDocument,
           })
           break
         case "available":
+          dispatch({
+            type: CatalogActionType.SET_ACTIVE_FILTERS,
+            payload: ["All", "Available"],
+          })
           dispatch({
             type: CatalogActionType.SET_QUERY,
             payload: ListStrainsInventoryDocument,

--- a/src/features/Stocks/Catalogs/Strains/StrainCatalogContainer.tsx
+++ b/src/features/Stocks/Catalogs/Strains/StrainCatalogContainer.tsx
@@ -163,7 +163,7 @@ const StrainCatalogContainer = ({ filter }: Props) => {
         case "regular":
           dispatch({
             type: CatalogActionType.SET_ACTIVE_FILTERS,
-            payload: ["Regular"]
+            payload: ["Regular"],
           })
           break
         case "gwdi":
@@ -204,6 +204,9 @@ const StrainCatalogContainer = ({ filter }: Props) => {
         default:
           return
       }
+
+      document.getElementById("search-input")?.focus()
+      return
     }
 
     updateData()

--- a/src/features/Stocks/Catalogs/common/AppBar/ActiveFilters.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/ActiveFilters.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+import { makeStyles } from "@material-ui/core/styles"
+import useCatalogStore from "features/Stocks/Catalogs/context/useCatalogStore"
+import { Chip, Box } from "@material-ui/core"
+import { CatalogActionType } from "features/Stocks/Catalogs/context/CatalogContext"
+
+const useStyles = makeStyles((theme) => ({
+  chipHolder: {
+    display: "flex",
+    alignItems: "center",
+    flexDirection: "row",
+    "& > div": {
+      marginRight: "3px",
+    },
+    "& > div:last-child": {
+      marginRight: "0",
+    },
+  },
+}))
+
+const ActiveFilters = () => {
+  const {
+    state: { activeFilters },
+    dispatch,
+  } = useCatalogStore()
+  const classes = useStyles()
+
+  const removeFilter = (index: number) => {
+    if (index >= activeFilters.length) return
+    dispatch({
+      type: CatalogActionType.SET_ACTIVE_FILTERS,
+      payload: activeFilters.filter((f, i) => i !== index),
+    })
+    document.getElementById("search-input")?.focus()
+  }
+
+  return (
+    <Box className={classes.chipHolder} role="chip-holder">
+      {activeFilters?.map((val, i) => (
+        <Chip
+          label={val}
+          onDelete={() => removeFilter(i)}
+          key={`chip${i}${val}`}
+          size="small"
+          role={`chip`}
+        />
+      ))}
+    </Box>
+  )
+}
+
+export default ActiveFilters

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
@@ -79,6 +79,7 @@ const AppBarDropdown = ({
   return (
     <FormControl className={classes.containerize}>
       <Select
+        role="appbar-dropdown"
         value={mappedDropdownValue}
         onChange={(event: any) => {
           const val = dropdownItems[event.target.value]

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
@@ -44,6 +44,27 @@ type Props = {
 }
 
 /**
+ * Maps the value from the filter query to the corresponding index value of the dropdown
+ * @param value value from the filter query. This value could be "regular", "gwdi", etc.
+ * @returns Index of the corresponding menu item
+ */
+const dropdownValueToIndexMap = (value: string): number => {
+  let index = 2
+  switch (value.toLowerCase()) {
+    case "regular":
+      index = 0
+      break
+    case "gwdi":
+      index = 1
+      break
+    case "bacterial":
+      index = 3
+      break
+  }
+  return index
+}
+
+/**
  * AppBarDropdown is a reusable dropdown menu component for the catalog appbars.
  */
 
@@ -55,17 +76,18 @@ const AppBarDropdown = ({
 }: Props) => {
   const classes = useStyles()
 
+  const mappedDropdownValue = dropdownValueToIndexMap(dropdownValue)
+
   return (
     <FormControl className={classes.containerize}>
       <Select
-        value={dropdownValue}
-        onChange={handleChange}
+        value={mappedDropdownValue}
         input={
           <Input disableUnderline name={inputName} data-testid={inputName} />
         }
         className={`${classes.containerize} ${classes.containedSelect}`}>
         {dropdownItems.map((item, index) => (
-          <MenuItem value={item.value} key={index}>
+          <MenuItem value={index} key={index}>
             {item.name}
           </MenuItem>
         ))}
@@ -75,3 +97,4 @@ const AppBarDropdown = ({
 }
 
 export default AppBarDropdown
+export { dropdownValueToIndexMap }

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
@@ -8,7 +8,8 @@ import { MenuItem } from "@material-ui/core"
 const useStyles = makeStyles({
   containerize: {
     minHeight: "inherit",
-    width: "100%",
+    minWidth: "190px",
+    maxWidth: "190px",
   },
   containedSelect: {
     display: "flex",

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
@@ -3,11 +3,26 @@ import { makeStyles } from "@material-ui/core/styles"
 import FormControl from "@material-ui/core/FormControl"
 import Select from "@material-ui/core/Select"
 import Input from "@material-ui/core/Input"
+import { MenuItem } from "@material-ui/core"
 
 const useStyles = makeStyles({
-  select: {
-    "&:focus": {
-      backgroundColor: "#fff",
+  containerize: {
+    minHeight: "inherit",
+    width: "100%",
+  },
+  containedSelect: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "inherit",
+    "& > div:focus": {
+      backgroundColor: "white",
+    },
+    "& > div": {
+      minHeight: "inherit",
+      display: "flex",
+      alignItems: "center",
+      padding: "0px 15px",
     },
   },
 })
@@ -41,25 +56,18 @@ const AppBarDropdown = ({
   const classes = useStyles()
 
   return (
-    <FormControl>
+    <FormControl className={classes.containerize}>
       <Select
-        native
         value={dropdownValue}
         onChange={handleChange}
         input={
-          <Input
-            disableUnderline
-            name={inputName}
-            data-testid={inputName}
-            classes={{
-              input: classes.select,
-            }}
-          />
-        }>
+          <Input disableUnderline name={inputName} data-testid={inputName} />
+        }
+        className={`${classes.containerize} ${classes.containedSelect}`}>
         {dropdownItems.map((item, index) => (
-          <option value={item.value} key={index}>
+          <MenuItem value={item.value} key={index}>
             {item.name}
-          </option>
+          </MenuItem>
         ))}
       </Select>
     </FormControl>

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarDropdown.tsx
@@ -36,9 +36,7 @@ type Props = {
   /** The currently selected dropdown value */
   dropdownValue: string
   /** Function to call on item select */
-  handleChange: (
-    event: React.ChangeEvent<{ name?: string; value: any }>,
-  ) => void
+  handleChange: (name: string, value: any) => void
   /** Name used to identify dropdown box */
   inputName: string
 }
@@ -82,6 +80,10 @@ const AppBarDropdown = ({
     <FormControl className={classes.containerize}>
       <Select
         value={mappedDropdownValue}
+        onChange={(event: any) => {
+          const val = dropdownItems[event.target.value]
+          handleChange(val.name, val.value)
+        }}
         input={
           <Input disableUnderline name={inputName} data-testid={inputName} />
         }

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarHelp.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarHelp.tsx
@@ -9,7 +9,14 @@ import HelpDialog from "features/Stocks/Catalogs/common/HelpDialog"
 
 const useStyles = makeStyles((theme: Theme) => ({
   helpIcon: {
-    color: theme.palette.primary.contrastText,
+    color: "#555",
+  },
+  helpButtonHolder: {
+    minHeight: "inherit",
+    display: "flex",
+    alignContent: "center",
+    justifyContent: "center",
+    padding: "15px 0px",
   },
 }))
 
@@ -29,7 +36,7 @@ const AppBarHelp = () => {
   }
 
   return (
-    <Box component="span" pr={1} pl={2}>
+    <Box className={classes.helpButtonHolder}>
       <IconButton
         size="small"
         onClick={handleClick}

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarLeftMenu.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarLeftMenu.tsx
@@ -32,10 +32,9 @@ const AppBarLeftMenu = ({ dropdownItems }: Props) => {
     }
   }, [filter, leftDropdownValue, setLeftDropdownValue])
 
-  const handleChange = (
-    event: React.ChangeEvent<{ name?: string; value: any }>,
-  ) => {
-    history.push(`?filter=${event.target.value}`)
+  const handleChange = (name: string, value: any) => {
+    // TODO: Dispatch SET_QUERY_VARIABLES with the new values
+    history.push(`?filter=${value}`)
   }
 
   return (

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarLeftMenu.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarLeftMenu.tsx
@@ -1,22 +1,9 @@
 import React from "react"
 import { useHistory } from "react-router-dom"
-import { makeStyles } from "@material-ui/core/styles"
-import Paper from "@material-ui/core/Paper"
 import AppBarDropdown from "./AppBarDropdown"
 import useSearchQuery from "common/hooks/useSearchQuery"
 import useCatalogStore from "features/Stocks/Catalogs/context/useCatalogStore"
 import useCatalogDispatch from "features/Stocks/Catalogs/context/useCatalogDispatch"
-
-const useStyles = makeStyles({
-  root: {
-    padding: "2px 4px",
-  },
-  select: {
-    "&:focus": {
-      backgroundColor: "#fff",
-    },
-  },
-})
 
 type Props = {
   dropdownItems: Array<{
@@ -33,7 +20,6 @@ type Props = {
 const AppBarLeftMenu = ({ dropdownItems }: Props) => {
   const query = useSearchQuery()
   const filter = query.get("filter") || "all"
-  const classes = useStyles()
   const history = useHistory()
   const {
     state: { leftDropdownValue },
@@ -53,14 +39,12 @@ const AppBarLeftMenu = ({ dropdownItems }: Props) => {
   }
 
   return (
-    <Paper className={classes.root}>
-      <AppBarDropdown
-        handleChange={handleChange}
-        dropdownValue={leftDropdownValue}
-        dropdownItems={dropdownItems}
-        inputName="catalog-filter"
-      />
-    </Paper>
+    <AppBarDropdown
+      handleChange={handleChange}
+      dropdownValue={leftDropdownValue}
+      dropdownItems={dropdownItems}
+      inputName="catalog-filter"
+    />
   )
 }
 

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
@@ -119,12 +119,8 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
         },
       })
       render(<MockComponent />)
-      const input = screen.getByPlaceholderText(
-        "Search entire catalog...",
-      ) as HTMLInputElement
-      const searchButton = screen.getByRole("button", {
-        name: /Catalog search icon/,
-      })
+      const input = screen.getByRole("search-input") as HTMLInputElement
+      const searchButton = screen.getByRole("search-button")
       userEvent.type(input, "GWDI")
       userEvent.click(searchButton)
       expect(mockSetQueryVariables).toHaveBeenCalledWith({

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import AppBarSearch from "./AppBarSearch"
 import { useHistory } from "react-router-dom"
@@ -88,22 +88,22 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
     })
     it("should render chip holder", () => {
       render(<MockComponent />)
-      expect(screen.getAllByRole("chip-holder")).toHaveLength(1)
+      expect(screen.getByRole("chip-holder")).toBeInTheDocument()
     })
   })
 
   describe("clear button", () => {
-    it("should clear text box", () => {
+    it("should clear text box", async () => {
       render(<MockComponent />)
-      const input = screen.getByPlaceholderText(
-        "Search entire catalog...",
-      ) as HTMLInputElement
-      const clearButton = screen.getByRole("button", {
-        name: /clear search box/,
+      const input = screen.getByRole("search-input") as HTMLInputElement
+      const clearButton = screen.getByRole("clear-search-button")
+      const searchVal = "GWDI"
+
+      userEvent.type(input, searchVal)
+      await waitFor(() => {
+        expect(input).toHaveValue(searchVal)
       })
-      userEvent.type(input, "GWDI")
-      // function should be called for each letter typed
-      expect(mockSetSearchValue).toHaveBeenCalledTimes(4)
+
       userEvent.click(clearButton)
       expect(mockSetSearchValue).toHaveBeenCalledWith("")
     })

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
@@ -82,9 +82,9 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
       render(<MockComponent />)
       expect(screen.getByRole("search-textbox")).toBeInTheDocument()
     })
-    it("should render two buttons", () => {
+    it("should render one button to clear search", () => {
       render(<MockComponent />)
-      expect(screen.getAllByRole("button")).toHaveLength(2)
+      expect(screen.getAllByRole("clear-search-button")).toHaveLength(1)
     })
     it("should render one dropdown with three items", () => {
       render(<MockComponent />)

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
@@ -141,14 +141,13 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
         },
       })
       render(<MockComponent />)
-      const dropdown = screen.getByRole("combobox")
-      userEvent.selectOptions(dropdown, "id")
-      const input = screen.getByPlaceholderText(
-        "Search entire catalog...",
-      ) as HTMLInputElement
-      const searchButton = screen.getByRole("button", {
-        name: /Catalog search icon/,
-      })
+
+      // TODO: Add fields test
+      // const dropdown = screen.getByRole("combobox")
+      // userEvent.selectOptions(dropdown, "id")
+      const input = screen.getByRole("search-input") as HTMLInputElement
+      const searchButton = screen.getByRole("search-button")
+
       userEvent.type(input, strainID)
       userEvent.click(searchButton)
       expect(mockHistoryPush).toHaveBeenCalledWith(`/strains/${strainID}`)
@@ -164,14 +163,13 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
         },
       })
       render(<MockComponent />)
-      const dropdown = screen.getByRole("combobox")
-      userEvent.selectOptions(dropdown, "id")
-      const input = screen.getByPlaceholderText(
-        "Search entire catalog...",
-      ) as HTMLInputElement
-      const searchButton = screen.getByRole("button", {
-        name: /Catalog search icon/,
-      })
+
+      // TODO: Add fields test
+      // const dropdown = screen.getByRole("combobox")
+      // userEvent.selectOptions(dropdown, "id")
+      const input = screen.getByRole("search-input") as HTMLInputElement
+      const searchButton = screen.getByRole("search-button")
+
       userEvent.type(input, plasmidID)
       userEvent.click(searchButton)
       expect(mockHistoryPush).toHaveBeenCalledWith(`/plasmids/${plasmidID}`)
@@ -187,14 +185,13 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
         },
       })
       render(<MockComponent />)
-      const dropdown = screen.getByRole("combobox")
-      userEvent.selectOptions(dropdown, "id")
-      const input = screen.getByPlaceholderText(
-        "Search entire catalog...",
-      ) as HTMLInputElement
-      const searchButton = screen.getByRole("button", {
-        name: /Catalog search icon/,
-      })
+
+      // TODO: Add fields test
+      // const dropdown = screen.getByRole("combobox")
+      // userEvent.selectOptions(dropdown, "id")
+      const input = screen.getByRole("search-input") as HTMLInputElement
+      const searchButton = screen.getByRole("search-button")
+
       userEvent.type(input, fakeStrainID)
       userEvent.click(searchButton)
       expect(mockHistoryPush).toHaveBeenCalledWith(
@@ -203,12 +200,13 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
     })
   })
 
-  describe("dropdown select", () => {
+  // TODO: Enable test when field dropdown is implemented
+  /* describe("dropdown select", () => {
     it("should change searchbox dropdown value", () => {
       render(<MockComponent />)
       const dropdown = screen.getByRole("combobox")
       userEvent.selectOptions(dropdown, "summary")
       expect(mockSetSearchBoxDropdownValue).toHaveBeenCalledWith("summary")
     })
-  })
+  }) */
 })

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
@@ -86,10 +86,9 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
       render(<MockComponent />)
       expect(screen.getAllByRole("clear-search-button")).toHaveLength(1)
     })
-    it("should render one dropdown with three items", () => {
+    it("should render one chip", () => {
       render(<MockComponent />)
-      expect(screen.getByRole("combobox")).toBeInTheDocument()
-      expect(screen.getAllByRole("option")).toHaveLength(3)
+      expect(screen.getAllByRole("chip1")).toHaveLength(1)
     })
   })
 

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
@@ -86,9 +86,9 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
       render(<MockComponent />)
       expect(screen.getAllByRole("clear-search-button")).toHaveLength(1)
     })
-    it("should render one chip", () => {
+    it("should render chip holder", () => {
       render(<MockComponent />)
-      expect(screen.getAllByRole("chip1")).toHaveLength(1)
+      expect(screen.getAllByRole("chip-holder")).toHaveLength(1)
     })
   })
 

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
@@ -80,7 +80,7 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
   describe("initial render", () => {
     it("should render one search box", () => {
       render(<MockComponent />)
-      expect(screen.getByRole("search-textbox")).toBeInTheDocument()
+      expect(screen.getByRole("search-input")).toBeInTheDocument()
     })
     it("should render one button to clear search", () => {
       render(<MockComponent />)

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.test.tsx
@@ -80,7 +80,7 @@ describe("Stocks/Catalog//common/AppBar/AppBarSearch", () => {
   describe("initial render", () => {
     it("should render one search box", () => {
       render(<MockComponent />)
-      expect(screen.getByRole("textbox")).toBeInTheDocument()
+      expect(screen.getByRole("search-textbox")).toBeInTheDocument()
     })
     it("should render two buttons", () => {
       render(<MockComponent />)

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -141,6 +141,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
             label={val}
             onDelete={() => removeFilter(i)}
             key={`chip${i}${val}`}
+            size="small"
           />
         ))}
       </Box>

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -3,18 +3,34 @@ import { useHistory } from "react-router-dom"
 import { makeStyles } from "@material-ui/core/styles"
 import useCatalogStore from "features/Stocks/Catalogs/context/useCatalogStore"
 import useCatalogDispatch from "features/Stocks/Catalogs/context/useCatalogDispatch"
-import { InputAdornment, TextField } from "@material-ui/core"
+import { InputAdornment, TextField, Chip, Box } from "@material-ui/core"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 const useStyles = makeStyles((theme) => ({
   searchForm: {
     minHeight: "inherit",
     width: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexDirection: "row",
+    padding: "0px 10px",
   },
   searchInput: {
     "& > div.MuiInputBase-root fieldset": {
       borderRadius: "0px",
       border: "0px solid transparent!important",
+    },
+  },
+  chipHolder: {
+    display: "flex",
+    alignItems: "center",
+    flexDirection: "row",
+    "& > div": {
+      marginRight: "3px",
+    },
+    "& > div:last-child": {
+      marginRight: "0",
     },
   },
 }))
@@ -109,6 +125,10 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
 
   return (
     <form onSubmit={handleSubmit} className={classes.searchForm}>
+      <Box className={classes.chipHolder}>
+        <Chip label="Label 1" onDelete={() => {}} />
+        <Chip label="Label 2" onDelete={() => {}} />
+      </Box>
       <TextField
         fullWidth
         inputProps={{ "aria-label": "search" }}

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -168,7 +168,8 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
               <IconButton
                 aria-label="toggle password visibility"
                 onClick={clearSearch}
-                edge="end">
+                edge="end"
+                role="clear-search-button">
                 <FontAwesomeIcon
                   icon="times"
                   size="xs"

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -155,7 +155,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
 
       <TextField
         fullWidth
-        inputProps={{ "aria-label": "search" }}
+        inputProps={{ role: "search-input" }}
         onChange={handleChange}
         value={searchValue}
         InputProps={{
@@ -167,10 +167,10 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
           endAdornment: (
             <InputAdornment position="end">
               <IconButton
-                aria-label="toggle password visibility"
                 onClick={clearSearch}
                 edge="end"
-                role="clear-search-button">
+                role="clear-search-button"
+                aria-label="clear search box">
                 <FontAwesomeIcon
                   icon="times"
                   size="xs"

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -5,6 +5,7 @@ import useCatalogStore from "features/Stocks/Catalogs/context/useCatalogStore"
 import useCatalogDispatch from "features/Stocks/Catalogs/context/useCatalogDispatch"
 import { InputAdornment, TextField, Chip, Box } from "@material-ui/core"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { CatalogActionType } from "features/Stocks/Catalogs/context/CatalogContext"
 
 const useStyles = makeStyles((theme) => ({
   searchForm: {
@@ -117,18 +118,33 @@ type Props = {
 
 const AppBarSearch = ({ dropdownItems }: Props) => {
   const {
-    state: { searchValue, searchBoxDropdownValue },
+    state: { searchValue, searchBoxDropdownValue, activeFilters },
+    dispatch,
   } = useCatalogStore()
   const classes = useStyles()
   const { handleChange, handleDropdownChange, handleSubmit, clearSearch } =
     useAppBarSearch()
 
+  const removeFilter = (index: number) => {
+    if (index >= activeFilters.length) return
+    dispatch({
+      type: CatalogActionType.SET_ACTIVE_FILTERS,
+      payload: activeFilters.filter((f, i) => i !== index),
+    })
+  }
+
   return (
     <form onSubmit={handleSubmit} className={classes.searchForm}>
       <Box className={classes.chipHolder}>
-        <Chip label="Label 1" onDelete={() => {}} />
-        <Chip label="Label 2" onDelete={() => {}} />
+        {activeFilters.map((val, i) => (
+          <Chip
+            label={val}
+            onDelete={() => removeFilter(i)}
+            key={`chip${i}${val}`}
+          />
+        ))}
       </Box>
+
       <TextField
         fullWidth
         inputProps={{ "aria-label": "search" }}

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -136,7 +136,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
   return (
     <form onSubmit={handleSubmit} className={classes.searchForm}>
       <Box className={classes.chipHolder}>
-        {activeFilters.map((val, i) => (
+        {activeFilters?.map((val, i) => (
           <Chip
             label={val}
             onDelete={() => removeFilter(i)}
@@ -161,6 +161,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
         variant="outlined"
         className={classes.searchInput}
         placeholder="Search entire catalog..."
+        role="search-textbox"
       />
       {/* <IconButton
             className={classes.iconButton}

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -1,31 +1,21 @@
 import React from "react"
 import { useHistory } from "react-router-dom"
 import { makeStyles } from "@material-ui/core/styles"
-import Grid from "@material-ui/core/Grid"
-import Paper from "@material-ui/core/Paper"
-import InputBase from "@material-ui/core/InputBase"
-import IconButton from "@material-ui/core/IconButton"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import AppBarDropdown from "./AppBarDropdown"
 import useCatalogStore from "features/Stocks/Catalogs/context/useCatalogStore"
 import useCatalogDispatch from "features/Stocks/Catalogs/context/useCatalogDispatch"
+import { InputAdornment, TextField } from "@material-ui/core"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 
 const useStyles = makeStyles((theme) => ({
-  input: {
-    marginLeft: theme.spacing(1),
-    flex: 1,
+  searchForm: {
+    minHeight: "inherit",
+    width: "100%",
   },
-  iconButton: {
-    padding: 10,
-  },
-  separator: {
-    borderLeftColor: "#bfbfbf",
-    borderLeftStyle: "solid",
-    borderLeftWidth: "1px",
-    display: "inline-block",
-    height: "30px",
-    verticalAlign: "middle",
-    paddingRight: "4px",
+  searchInput: {
+    "& > div.MuiInputBase-root fieldset": {
+      borderRadius: "0px",
+      border: "0px solid transparent!important",
+    },
   },
 }))
 
@@ -51,11 +41,8 @@ const useAppBarSearch = () => {
   const {
     state: { searchValue, searchBoxDropdownValue, leftDropdownValue },
   } = useCatalogStore()
-  const {
-    setQueryVariables,
-    setSearchValue,
-    setSearchBoxDropdownValue,
-  } = useCatalogDispatch()
+  const { setQueryVariables, setSearchValue, setSearchBoxDropdownValue } =
+    useCatalogDispatch()
   const history = useHistory()
 
   const handleChange = (
@@ -117,47 +104,41 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
     state: { searchValue, searchBoxDropdownValue },
   } = useCatalogStore()
   const classes = useStyles()
-  const {
-    handleChange,
-    handleDropdownChange,
-    handleSubmit,
-    clearSearch,
-  } = useAppBarSearch()
+  const { handleChange, handleDropdownChange, handleSubmit, clearSearch } =
+    useAppBarSearch()
 
   return (
-    <form onSubmit={handleSubmit}>
-      <Paper>
-        <Grid container alignItems="center">
-          <IconButton
-            className={classes.iconButton}
-            aria-label="Catalog search icon"
-            title="Search entire catalog"
-            onClick={handleSubmit}>
-            <FontAwesomeIcon icon="search" size="sm" />
-          </IconButton>
-          <InputBase
-            className={classes.input}
-            placeholder="Search entire catalog..."
-            inputProps={{ "aria-label": "search" }}
-            onChange={handleChange}
-            value={searchValue}
-          />
-          <IconButton
+    <form onSubmit={handleSubmit} className={classes.searchForm}>
+      {/* <TextField
+        placeholder="Search entire catalog..."
+        inputProps={{ "aria-label": "search" }}
+        onChange={handleChange}
+        value={searchValue}
+        label="Search"
+      /> */}
+      <TextField
+        fullWidth
+        inputProps={{ "aria-label": "search" }}
+        onChange={handleChange}
+        value={searchValue}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <FontAwesomeIcon icon={"search"} />
+            </InputAdornment>
+          ),
+        }}
+        variant="outlined"
+        className={classes.searchInput}
+        placeholder="Search entire catalog..."
+      />
+      {/* <IconButton
             className={classes.iconButton}
             title="Clear search box"
             aria-label="clear search box"
             onClick={clearSearch}>
             <FontAwesomeIcon icon="times" size="sm" />
-          </IconButton>
-          <div className={classes.separator} />
-          <AppBarDropdown
-            dropdownItems={dropdownItems}
-            handleChange={handleDropdownChange}
-            dropdownValue={searchBoxDropdownValue}
-            inputName="catalog-search-filter"
-          />
-        </Grid>
-      </Paper>
+          </IconButton> */}
     </form>
   )
 }

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -3,7 +3,13 @@ import { useHistory } from "react-router-dom"
 import { makeStyles } from "@material-ui/core/styles"
 import useCatalogStore from "features/Stocks/Catalogs/context/useCatalogStore"
 import useCatalogDispatch from "features/Stocks/Catalogs/context/useCatalogDispatch"
-import { InputAdornment, TextField, Chip, Box } from "@material-ui/core"
+import {
+  InputAdornment,
+  TextField,
+  Chip,
+  Box,
+  IconButton,
+} from "@material-ui/core"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { CatalogActionType } from "features/Stocks/Catalogs/context/CatalogContext"
 
@@ -157,19 +163,26 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
               <FontAwesomeIcon icon={"search"} />
             </InputAdornment>
           ),
+          endAdornment: (
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={clearSearch}
+                edge="end">
+                <FontAwesomeIcon
+                  icon="times"
+                  size="xs"
+                  visibility={searchValue.length === 0 ? "hidden" : "visible"}
+                />
+              </IconButton>
+            </InputAdornment>
+          ),
         }}
         variant="outlined"
         className={classes.searchInput}
         placeholder="Search entire catalog..."
         role="search-textbox"
       />
-      {/* <IconButton
-            className={classes.iconButton}
-            title="Clear search box"
-            aria-label="clear search box"
-            onClick={clearSearch}>
-            <FontAwesomeIcon icon="times" size="sm" />
-          </IconButton> */}
     </form>
   )
 }

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -3,15 +3,10 @@ import { useHistory } from "react-router-dom"
 import { makeStyles } from "@material-ui/core/styles"
 import useCatalogStore from "features/Stocks/Catalogs/context/useCatalogStore"
 import useCatalogDispatch from "features/Stocks/Catalogs/context/useCatalogDispatch"
-import {
-  InputAdornment,
-  TextField,
-  Chip,
-  Box,
-  IconButton,
-} from "@material-ui/core"
+import { InputAdornment, TextField, IconButton } from "@material-ui/core"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { CatalogActionType } from "features/Stocks/Catalogs/context/CatalogContext"
+import ActiveFilters from "./ActiveFilters"
 
 const useStyles = makeStyles((theme) => ({
   searchForm: {
@@ -27,17 +22,6 @@ const useStyles = makeStyles((theme) => ({
     "& > div.MuiInputBase-root fieldset": {
       borderRadius: "0px",
       border: "0px solid transparent!important",
-    },
-  },
-  chipHolder: {
-    display: "flex",
-    alignItems: "center",
-    flexDirection: "row",
-    "& > div": {
-      marginRight: "3px",
-    },
-    "& > div:last-child": {
-      marginRight: "0",
     },
   },
 }))
@@ -131,15 +115,6 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
   const { handleChange, handleDropdownChange, handleSubmit, clearSearch } =
     useAppBarSearch()
 
-  const removeFilter = (index: number) => {
-    if (index >= activeFilters.length) return
-    dispatch({
-      type: CatalogActionType.SET_ACTIVE_FILTERS,
-      payload: activeFilters.filter((f, i) => i !== index),
-    })
-    document.getElementById("search-input")?.focus()
-  }
-
   const clearFiltersFromInput = (e: React.KeyboardEvent<any>) => {
     // Remove filters if user hits backspace
     // while both searchValue, and activeFilters are empty
@@ -160,17 +135,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
 
   return (
     <form onSubmit={handleSubmit} className={classes.searchForm}>
-      <Box className={classes.chipHolder} role="chip-holder">
-        {activeFilters?.map((val, i) => (
-          <Chip
-            label={val}
-            onDelete={() => removeFilter(i)}
-            key={`chip${i}${val}`}
-            size="small"
-            role={`chip`}
-          />
-        ))}
-      </Box>
+      <ActiveFilters />
 
       <TextField
         fullWidth

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -168,22 +168,21 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
               <FontAwesomeIcon icon={"search"} style={{ cursor: "pointer" }} />
             </InputAdornment>
           ),
-          endAdornment: (
-            <InputAdornment position="end">
-              <IconButton
-                onClick={clearSearch}
-                edge="end"
-                role="clear-search-button"
-                style={{ width: "36px", height: "36px" }}
-                aria-label="clear search box">
-                <FontAwesomeIcon
-                  icon="times"
-                  size="xs"
-                  visibility={searchValue.length === 0 ? "hidden" : "visible"}
-                />
-              </IconButton>
-            </InputAdornment>
-          ),
+          endAdornment:
+            searchValue.length > 0 ? (
+              <InputAdornment position="end">
+                <IconButton
+                  onClick={clearSearch}
+                  edge="end"
+                  role="clear-search-button"
+                  style={{ width: "36px", height: "36px" }}
+                  aria-label="clear search box">
+                  <FontAwesomeIcon icon="times" size="xs" />
+                </IconButton>
+              </InputAdornment>
+            ) : (
+              <></>
+            ),
         }}
         variant="outlined"
         className={classes.searchInput}

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -187,7 +187,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
         variant="outlined"
         className={classes.searchInput}
         placeholder="Search entire catalog..."
-        role="search-textbox"
+        autoFocus={true}
       />
     </form>
   )

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -148,6 +148,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
             onDelete={() => removeFilter(i)}
             key={`chip${i}${val}`}
             size="small"
+            role={`chip${i + 1}`}
           />
         ))}
       </Box>

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -137,6 +137,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
       type: CatalogActionType.SET_ACTIVE_FILTERS,
       payload: activeFilters.filter((f, i) => i !== index),
     })
+    document.getElementById("search-input")?.focus()
   }
 
   return (
@@ -155,7 +156,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
 
       <TextField
         fullWidth
-        inputProps={{ role: "search-input" }}
+        inputProps={{ role: "search-input", id: "search-input" }}
         onChange={handleChange}
         value={searchValue}
         InputProps={{

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -140,6 +140,24 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
     document.getElementById("search-input")?.focus()
   }
 
+  const clearFiltersFromInput = (e: React.KeyboardEvent<any>) => {
+    // Remove filters if user hits backspace
+    // while both searchValue, and activeFilters are empty
+    if (
+      searchValue.length === 0 &&
+      activeFilters.length > 0 &&
+      e.key === "Backspace"
+    ) {
+      const newActiveFilters = activeFilters
+      newActiveFilters.pop()
+
+      dispatch({
+        type: CatalogActionType.SET_ACTIVE_FILTERS,
+        payload: newActiveFilters,
+      })
+    }
+  }
+
   return (
     <form onSubmit={handleSubmit} className={classes.searchForm}>
       <Box className={classes.chipHolder} role="chip-holder">
@@ -158,6 +176,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
         fullWidth
         inputProps={{ role: "search-input", id: "search-input" }}
         onChange={handleChange}
+        onKeyDown={clearFiltersFromInput}
         value={searchValue}
         InputProps={{
           startAdornment: (

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -109,13 +109,6 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
 
   return (
     <form onSubmit={handleSubmit} className={classes.searchForm}>
-      {/* <TextField
-        placeholder="Search entire catalog..."
-        inputProps={{ "aria-label": "search" }}
-        onChange={handleChange}
-        value={searchValue}
-        label="Search"
-      /> */}
       <TextField
         fullWidth
         inputProps={{ "aria-label": "search" }}

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -160,8 +160,11 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
         value={searchValue}
         InputProps={{
           startAdornment: (
-            <InputAdornment position="start">
-              <FontAwesomeIcon icon={"search"} />
+            <InputAdornment
+              position="start"
+              onClick={handleSubmit}
+              role="search-button">
+              <FontAwesomeIcon icon={"search"} style={{ cursor: "pointer" }} />
             </InputAdornment>
           ),
           endAdornment: (
@@ -170,6 +173,7 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
                 onClick={clearSearch}
                 edge="end"
                 role="clear-search-button"
+                style={{ width: "36px", height: "36px" }}
                 aria-label="clear search box">
                 <FontAwesomeIcon
                   icon="times"

--- a/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
+++ b/src/features/Stocks/Catalogs/common/AppBar/AppBarSearch.tsx
@@ -141,14 +141,14 @@ const AppBarSearch = ({ dropdownItems }: Props) => {
 
   return (
     <form onSubmit={handleSubmit} className={classes.searchForm}>
-      <Box className={classes.chipHolder}>
+      <Box className={classes.chipHolder} role="chip-holder">
         {activeFilters?.map((val, i) => (
           <Chip
             label={val}
             onDelete={() => removeFilter(i)}
             key={`chip${i}${val}`}
             size="small"
-            role={`chip${i + 1}`}
+            role={`chip`}
           />
         ))}
       </Box>

--- a/src/features/Stocks/Catalogs/common/CatalogAppBar.tsx
+++ b/src/features/Stocks/Catalogs/common/CatalogAppBar.tsx
@@ -72,9 +72,7 @@ const CatalogAppBar = ({ leftDropdownItems, rightDropdownItems }: Props) => {
           </Box>
           <Hidden smDown>
             <Box flex="1" className={classes.toolbarOption}>
-              <Grid container justify="flex-end">
-                <AppBarRightMenu />
-              </Grid>
+              <AppBarRightMenu />
             </Box>
           </Hidden>
         </Box>

--- a/src/features/Stocks/Catalogs/common/CatalogAppBar.tsx
+++ b/src/features/Stocks/Catalogs/common/CatalogAppBar.tsx
@@ -6,7 +6,38 @@ import Hidden from "@material-ui/core/Hidden"
 import AppBarLeftMenu from "features/Stocks/Catalogs/common/AppBar/AppBarLeftMenu"
 import AppBarSearch from "features/Stocks/Catalogs/common/AppBar/AppBarSearch"
 import AppBarRightMenu from "features/Stocks/Catalogs/common/AppBar/AppBarRightMenu"
-import useStyles from "features/Stocks/Catalogs/styles"
+import { Box, makeStyles } from "@material-ui/core"
+
+const useStyles = makeStyles((theme) => ({
+  appBar: {
+    border: "1px #eee solid",
+    borderRadius: "4px",
+    borderBottomLeftRadius: "0",
+    borderBottomRightRadius: "0",
+    backgroundColor: "white",
+  },
+  toolbar: {
+    margin: 0,
+    padding: 0,
+    display: "block",
+    minHeight: "56px!important",
+  },
+  toolbarInner: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-evenly",
+    flexDirection: "row",
+    width: "100%",
+    minHeight: "inherit",
+  },
+  toolbarOption: {
+    display: "block",
+    minHeight: "inherit",
+    width: "100%",
+    borderRight: "1px solid #eee",
+    "&:last-child": { borderRight: "0px" },
+  },
+}))
 
 type Props = {
   /** List of items to display in left dropdown menu */
@@ -28,28 +59,25 @@ const CatalogAppBar = ({ leftDropdownItems, rightDropdownItems }: Props) => {
 
   return (
     <AppBar position="static" className={classes.appBar}>
-      <Toolbar>
-        <Grid container alignItems="center">
+      <Toolbar className={classes.toolbar}>
+        <Box className={classes.toolbarInner}>
+          <Box
+            flex="2"
+            className={classes.toolbarOption}
+            style={{ minWidth: "185px" }}>
+            <AppBarLeftMenu dropdownItems={leftDropdownItems} />
+          </Box>
+          <Box flex="9" className={classes.toolbarOption}>
+            <AppBarSearch dropdownItems={rightDropdownItems} />
+          </Box>
           <Hidden smDown>
-            <Grid item xs={4}>
-              <Grid container justify="flex-start">
-                <AppBarLeftMenu dropdownItems={leftDropdownItems} />
-              </Grid>
-            </Grid>
-          </Hidden>
-          <Grid item xs={12} md={4}>
-            <Grid container justify="center">
-              <AppBarSearch dropdownItems={rightDropdownItems} />
-            </Grid>
-          </Grid>
-          <Hidden smDown>
-            <Grid item xs={4}>
+            <Box flex="1" className={classes.toolbarOption}>
               <Grid container justify="flex-end">
                 <AppBarRightMenu />
               </Grid>
-            </Grid>
+            </Box>
           </Hidden>
-        </Grid>
+        </Box>
       </Toolbar>
     </AppBar>
   )

--- a/src/features/Stocks/Catalogs/common/CatalogAppBar.tsx
+++ b/src/features/Stocks/Catalogs/common/CatalogAppBar.tsx
@@ -62,10 +62,7 @@ const CatalogAppBar = ({ leftDropdownItems, rightDropdownItems }: Props) => {
     <AppBar position="static" className={classes.appBar}>
       <Toolbar className={classes.toolbar}>
         <Box className={classes.toolbarInner}>
-          <Box
-            flex="2"
-            className={classes.toolbarOption}
-            style={{ minWidth: "185px" }}>
+          <Box flex="1" className={classes.toolbarOption}>
             <AppBarLeftMenu dropdownItems={leftDropdownItems} />
           </Box>
           <Box flex="9" className={classes.toolbarOption}>

--- a/src/features/Stocks/Catalogs/common/CatalogAppBar.tsx
+++ b/src/features/Stocks/Catalogs/common/CatalogAppBar.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import AppBar from "@material-ui/core/AppBar"
 import Toolbar from "@material-ui/core/Toolbar"
-import Grid from "@material-ui/core/Grid"
 import Hidden from "@material-ui/core/Hidden"
 import AppBarLeftMenu from "features/Stocks/Catalogs/common/AppBar/AppBarLeftMenu"
 import AppBarSearch from "features/Stocks/Catalogs/common/AppBar/AppBarSearch"
@@ -15,6 +14,8 @@ const useStyles = makeStyles((theme) => ({
     borderBottomLeftRadius: "0",
     borderBottomRightRadius: "0",
     backgroundColor: "white",
+    boxShadow:
+      "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)!important",
   },
   toolbar: {
     margin: 0,

--- a/src/features/Stocks/Catalogs/context/CatalogContext.tsx
+++ b/src/features/Stocks/Catalogs/context/CatalogContext.tsx
@@ -30,6 +30,8 @@ type CatalogState = {
   helpDialogOpen: boolean
   /** The value selected from the left dropdown menu */
   leftDropdownValue: string
+  /** List of active filters (Chips) displayed in AppBarSearch */
+  activeFilters: string[]
 }
 
 enum CatalogActionType {
@@ -40,6 +42,7 @@ enum CatalogActionType {
   SET_SEARCH_VALUE = "SET_SEARCH_VALUE",
   SET_HELP_DIALOG_OPEN = "SET_HELP_DIALOG_OPEN",
   SET_LEFT_DROPDOWN_VALUE = "SET_LEFT_DROPDOWN_VALUE",
+  SET_ACTIVE_FILTERS = "SET_ACTIVE_FILTERS",
 }
 
 type Action =
@@ -71,6 +74,10 @@ type Action =
       type: CatalogActionType.SET_LEFT_DROPDOWN_VALUE
       payload: string
     }
+  | {
+      type: CatalogActionType.SET_ACTIVE_FILTERS
+      payload: string[]
+    }
 
 const initialState = {
   queryVariables: { cursor: 0, limit: 10, filter: "" },
@@ -78,6 +85,7 @@ const initialState = {
   leftDropdownValue: "all",
   searchValue: "",
   helpDialogOpen: false,
+  activeFilters: [],
 }
 
 const strainInitialState = {
@@ -137,6 +145,11 @@ const catalogReducer = (state: CatalogState, action: Action) => {
       return {
         ...state,
         leftDropdownValue: action.payload,
+      }
+    case CatalogActionType.SET_ACTIVE_FILTERS:
+      return {
+        ...state,
+        activeFilters: [...action.payload],
       }
     default:
       return state


### PR DESCRIPTION
![Catalog search preview with bacterial strands filter](https://user-images.githubusercontent.com/25919063/136628734-ba6182ec-fffb-4518-a3f7-6cbd227c714a.png)

![Catalog search preview with an open menu with all available filter](https://user-images.githubusercontent.com/25919063/136628860-685cf9d3-9e8e-48b8-adfd-2745eee01116.png)


- [x] Added 1 new state to hold active filters array
- [x] Changed UI (Which can easily be changed to something else down the line)
- [x] Update active filters chip using both the select dropdown as well as `?filter` query
- [x] Remove active filter chips by pressing the close button
- [x] Set input to active when user has select from the dropdown
- [ ] Update query with the active filters `strain_type` (to fetch with GraphQL)
- [ ] Add autocomplete